### PR TITLE
remove console.log and thread action thru active container to card

### DIFF
--- a/frontend/src/components/map/map_container.js
+++ b/frontend/src/components/map/map_container.js
@@ -5,7 +5,6 @@ import { fetchTasks } from '../../actions/task_actions';
 import { receiveActiveTaskId } from '../../actions/active_task_actions';
 
 const mSTP = state => {
-  console.log(state.ui.activeTask)
   return ({
     tasks: Object.values(state.tasks),
     activeTask: state.ui.activeTask

--- a/frontend/src/components/sidebar/active.jsx
+++ b/frontend/src/components/sidebar/active.jsx
@@ -29,7 +29,9 @@ class ActiveSidebar extends React.Component {
                                         openModal={openModal}
                                         closeModal={closeModal}
                                         currentUserId={currentUserId}
-                                        history={history} />
+                                        history={history} 
+                                        activeTask={this.props.activeTask}
+                                        receiveActiveTaskId={this.props.receiveActiveTaskId} />
                                 })
                             }
                         </div>

--- a/frontend/src/components/sidebar/available.jsx
+++ b/frontend/src/components/sidebar/available.jsx
@@ -22,7 +22,7 @@ class AvailableSidebar extends React.Component {
                                     currentUserId={currentUserId}
                                     history={history}
                                     activeTask={this.props.activeTask}
-                                    receiveActiveTaskId={this.props.receiveActiveTaskId}     />
+                                    receiveActiveTaskId={this.props.receiveActiveTaskId} />
                     })
                 }
             </div>


### PR DESCRIPTION
- fixed so that on hover of an active task card it will dispatch the ID to the relevant slice of UI state